### PR TITLE
Support runtime resolution change

### DIFF
--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -13,8 +13,7 @@ public class CommandBufferBlur : MonoBehaviour
     Camera _Camera = null;
     CommandBuffer _CommandBuffer = null;
 
-    private int prevW = 0;
-    private int prevH = 0;
+    Vector2 _ScreenResolution = Vector2.zero;
 
     public void Cleanup()
     {
@@ -91,13 +90,14 @@ public class CommandBufferBlur : MonoBehaviour
 
         _Camera.AddCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
 
-        prevW = Screen.width;
-        prevH = Screen.height;
+        _ScreenResolution = new Vector2(Screen.width, Screen.height);
     }
 
     void OnPreRender()
     {
-        if ((Screen.width != prevW) || (Screen.height != prevH)) Cleanup();
+        if (_ScreenResolution != new Vector2(Screen.width, Screen.height))
+            Cleanup();
+
         Initialize();
     }
 }

--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -13,6 +13,9 @@ public class CommandBufferBlur : MonoBehaviour
     Camera _Camera = null;
     CommandBuffer _CommandBuffer = null;
 
+	private int prevW = 0;
+	private int prevH = 0;
+
     public void Cleanup()
     {
         if (!Initialized)
@@ -87,10 +90,14 @@ public class CommandBufferBlur : MonoBehaviour
         }
 
         _Camera.AddCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
+
+		prevW = Screen.width;
+		prevH = Screen.height;
     }
 
     void OnPreRender()
     {
+		if ((Screen.width != prevW) || (Screen.height != prevH)) Cleanup();
         Initialize();
     }
 }

--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -13,8 +13,8 @@ public class CommandBufferBlur : MonoBehaviour
     Camera _Camera = null;
     CommandBuffer _CommandBuffer = null;
 
-	private int prevW = 0;
-	private int prevH = 0;
+    private int prevW = 0;
+    private int prevH = 0;
 
     public void Cleanup()
     {
@@ -91,13 +91,13 @@ public class CommandBufferBlur : MonoBehaviour
 
         _Camera.AddCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
 
-		prevW = Screen.width;
-		prevH = Screen.height;
+        prevW = Screen.width;
+        prevH = Screen.height;
     }
 
     void OnPreRender()
     {
-		if ((Screen.width != prevW) || (Screen.height != prevH)) Cleanup();
+        if ((Screen.width != prevW) || (Screen.height != prevH)) Cleanup();
         Initialize();
     }
 }


### PR DESCRIPTION
This will automatically detect if the rendering resolution has changed, and will re-generate the command buffer if it has. This check should be a negligible amount of overhead, but if there's some more appropriate 'onresize' type event, let me know.