### PR TITLE
 Make blur distance independent of resolution & FOV

### DIFF
--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -15,6 +15,9 @@ public class CommandBufferBlur : MonoBehaviour
 
     Vector2 _ScreenResolution = Vector2.zero;
     float _OldFov = 0;
+    float _OldStepDist = 0;
+
+    public float blurStepDistance = 0.1f;
 
     public void Cleanup()
     {
@@ -60,7 +63,7 @@ public class CommandBufferBlur : MonoBehaviour
 
         int numIterations = 4;
 
-        float stepSize = 0.1f / _Camera.fieldOfView;
+        float stepSize = blurStepDistance / _Camera.fieldOfView;
         Vector2 offsets = new Vector2(stepSize * Screen.height / Screen.width, stepSize);
 
         
@@ -95,11 +98,12 @@ public class CommandBufferBlur : MonoBehaviour
 
         _ScreenResolution = new Vector2(Screen.width, Screen.height);
         _OldFov = _Camera.fieldOfView;
+		_OldStepDist = blurStepDistance;
     }
 
     void OnPreRender()
     {
-        if ((_ScreenResolution != new Vector2(Screen.width, Screen.height)) || (_Camera.fieldOfView != _OldFov))
+        if ((_ScreenResolution != new Vector2(Screen.width, Screen.height)) || (_Camera.fieldOfView != _OldFov) || (_OldStepDist != blurStepDistance))
             Cleanup();
 
         Initialize();

--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -64,7 +64,7 @@ public class CommandBufferBlur : MonoBehaviour
         int numIterations = 4;
 
         float stepSize = blurStepDistance / _Camera.fieldOfView;
-        Vector2 offsets = new Vector2(stepSize * Screen.height / Screen.width, stepSize);
+        Vector2 offsets = new Vector2(stepSize * _Camera.pixelHeight / _Camera.pixelWidth, stepSize);
 
         
 
@@ -75,8 +75,8 @@ public class CommandBufferBlur : MonoBehaviour
             _CommandBuffer.Blit(BuiltinRenderTextureType.CurrentActive, screenCopyID);
 
             int curSize = (int)Mathf.Pow(2,i);
-            int curW = Screen.width/curSize;
-            int curH = Screen.height/curSize;
+            int curW = _Camera.pixelWidth/curSize;
+            int curH = _Camera.pixelHeight/curSize;
 
             int blurredID = Shader.PropertyToID("_Grab" + i + "_Temp1");
             int blurredID2 = Shader.PropertyToID("_Grab" + i + "_Temp2");
@@ -96,14 +96,14 @@ public class CommandBufferBlur : MonoBehaviour
 
         _Camera.AddCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
 
-        _ScreenResolution = new Vector2(Screen.width, Screen.height);
+        _ScreenResolution = new Vector2(_Camera.pixelWidth, _Camera.pixelHeight);
         _OldFov = _Camera.fieldOfView;
 		_OldStepDist = blurStepDistance;
     }
 
     void OnPreRender()
     {
-        if ((_ScreenResolution != new Vector2(Screen.width, Screen.height)) || (_Camera.fieldOfView != _OldFov) || (_OldStepDist != blurStepDistance))
+        if ((_ScreenResolution != new Vector2(_Camera.pixelWidth, _Camera.pixelHeight)) || (_Camera.fieldOfView != _OldFov) || (_OldStepDist != blurStepDistance))
             Cleanup();
 
         Initialize();


### PR DESCRIPTION
Previously, the image would always be blurred by a certain number of *pixels*, which meant that as the resolution increased, the apparent amount of blur (relative to the world/image) *decreased* (by staying the same as the resolution went up).

This new approach takes the resolution and FOV into account when determining how far across the texture to sample for the blur; this means that a given view of the world will always look (essentially) the same regardless of how "big" it's rendering.

The one problem that this fix reveals, is that for a sufficiently high resolution (or sufficiently narrow FOV), the step between blur samples may be noticeably larger than a single on-screen pixel, which would introduce a visual 'echoing' effect. In this case, the `blur step distance` value may be decreased until the problem is no longer visible -- the only downside to this is that doing so will decrease the distance over which the image is blurred (in world terms), which may be undesired. (This could be compensated for by adding more blur iterations, but as that's hardcoded into the shader as well as the CommandBuffer, there's no simple way to change that without manually editing the shader's code, as far as I'm aware.) Of course, users can also choose to adjust the `blur step distance` for purely aesthetic reasons, to change the range of possible amounts of diffusion that the values in the texture correspond to, so that's just a fun freebie :)