### PR TITLE
Allow effect to work without skyboxes

### DIFF
--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -20,7 +20,7 @@ public class CommandBufferBlur : MonoBehaviour
         if (!Initialized)
             return;
 
-        _Camera.RemoveCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
+        _Camera.RemoveCommandBuffer(CameraEvent.BeforeForwardAlpha, _CommandBuffer);
         _CommandBuffer = null;
         Object.DestroyImmediate(_Material);
     }
@@ -88,7 +88,7 @@ public class CommandBufferBlur : MonoBehaviour
             _CommandBuffer.SetGlobalTexture("_GrabBlurTexture_" + i, blurredID);
         }
 
-        _Camera.AddCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
+        _Camera.AddCommandBuffer(CameraEvent.BeforeForwardAlpha, _CommandBuffer);
 
         _ScreenResolution = new Vector2(Screen.width, Screen.height);
     }


### PR DESCRIPTION
This gives the same result, but will also work on cameras that don't draw skyboxes (i.e. in scenes with flat-color backgrounds, or in scenes with multiple cameras, only one of which draws the skybox, and another of which draws the frosted glass).