### PR TITLE
Added support for previewing the effect in Scene View

### DIFF
--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -6,9 +6,6 @@ using UnityEngine.Rendering;
 [RequireComponent(typeof(Camera))]
 public class CommandBufferBlur : MonoBehaviour
 {
-    private static Shader _STATIC_SHADER;
-
-    [SerializeField]
     Shader _Shader;
 
     Material _Material = null;
@@ -49,9 +46,17 @@ public class CommandBufferBlur : MonoBehaviour
         if (Initialized)
             return;
 
+        if (!_Shader)
+        {
+            _Shader = Shader.Find("Hidden/SeparableGlassBlur");
+
+            if (!_Shader)
+                throw new MissingReferenceException("Unable to find required shader \"Hidden/SeparableGlassBlur\"");
+        }
+
         if (!_Material)
         {
-            _Material = new Material(_Shader != null ? _Shader : _STATIC_SHADER);
+            _Material = new Material(_Shader);
             _Material.hideFlags = HideFlags.HideAndDontSave;
         }
 
@@ -102,13 +107,5 @@ public class CommandBufferBlur : MonoBehaviour
             Cleanup();
 
         Initialize();
-    }
-
-    void OnValidate()
-    {
-        if(_STATIC_SHADER != _Shader && _Shader != null)
-        {
-            _STATIC_SHADER = _Shader;
-        }
     }
 }

--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -2,9 +2,12 @@
 using UnityEngine.Rendering;
 
 [ExecuteInEditMode]
+[ImageEffectAllowedInSceneView]
 [RequireComponent(typeof(Camera))]
 public class CommandBufferBlur : MonoBehaviour
 {
+    private static Shader _STATIC_SHADER;
+
     [SerializeField]
     Shader _Shader;
 
@@ -20,7 +23,7 @@ public class CommandBufferBlur : MonoBehaviour
         if (!Initialized)
             return;
 
-        _Camera.RemoveCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
+        _Camera.RemoveCommandBuffer(CameraEvent.BeforeForwardAlpha, _CommandBuffer);
         _CommandBuffer = null;
         Object.DestroyImmediate(_Material);
     }
@@ -48,7 +51,7 @@ public class CommandBufferBlur : MonoBehaviour
 
         if (!_Material)
         {
-            _Material = new Material(_Shader);
+            _Material = new Material(_Shader != null ? _Shader : _STATIC_SHADER);
             _Material.hideFlags = HideFlags.HideAndDontSave;
         }
 
@@ -88,7 +91,7 @@ public class CommandBufferBlur : MonoBehaviour
             _CommandBuffer.SetGlobalTexture("_GrabBlurTexture_" + i, blurredID);
         }
 
-        _Camera.AddCommandBuffer(CameraEvent.AfterSkybox, _CommandBuffer);
+        _Camera.AddCommandBuffer(CameraEvent.BeforeForwardAlpha, _CommandBuffer);
 
         _ScreenResolution = new Vector2(Screen.width, Screen.height);
     }
@@ -99,5 +102,13 @@ public class CommandBufferBlur : MonoBehaviour
             Cleanup();
 
         Initialize();
+    }
+
+    void OnValidate()
+    {
+        if(_STATIC_SHADER != _Shader && _Shader != null)
+        {
+            _STATIC_SHADER = _Shader;
+        }
     }
 }

--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs.meta
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs.meta
@@ -1,10 +1,12 @@
 fileFormatVersion: 2
 guid: b9d8a614237130a418a3c62d7f3bd111
-timeCreated: 1517197309
+timeCreated: 1530613174
 licenseType: Free
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - _Shader: {fileID: 4800000, guid: 6f901473b0e75314f9ea31900b25fd94, type: 3}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 


### PR DESCRIPTION
- Added the [ImageEffectAllowedInSceneView] annotation.
- Added a static Shader reference populated on Validate.
- Since CameraEvent.AfterSkybox did not appear to work in Scene View, changed to CameraEvent.BeforeForwardAlpha, which is supposedly the next event chronologically, and this seemed to work. 
This issue has been raised in the Unity Forums: https://forum.unity.com/threads/what-is-the-order-of-commandbuffer-cameraevents-in-each-render-path-and-editor-view.538862/