### PR TITLE
Use HDR when possible

### DIFF
--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -14,6 +14,7 @@ public class CommandBufferBlur : MonoBehaviour
     CommandBuffer _CommandBuffer = null;
 
     Vector2 _ScreenResolution = Vector2.zero;
+    RenderTextureFormat _BufferRenderTextureFormat;
 
     public void Cleanup()
     {
@@ -62,6 +63,13 @@ public class CommandBufferBlur : MonoBehaviour
 
         _Camera = GetComponent<Camera>();
 
+        if (_Camera.allowHDR && SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.DefaultHDR))
+        {
+            _BufferRenderTextureFormat = RenderTextureFormat.DefaultHDR;
+        } else {
+            _BufferRenderTextureFormat = RenderTextureFormat.ARGB32;
+        }
+
         _CommandBuffer = new CommandBuffer();
         _CommandBuffer.name = "Blur screen";
 
@@ -77,13 +85,13 @@ public class CommandBufferBlur : MonoBehaviour
         for (int i = 0; i < numIterations; ++i)
         {
             int screenCopyID = Shader.PropertyToID("_ScreenCopyTexture");
-            _CommandBuffer.GetTemporaryRT(screenCopyID, -1, -1, 0, FilterMode.Bilinear);
+            _CommandBuffer.GetTemporaryRT(screenCopyID, -1, -1, 0, FilterMode.Bilinear, _BufferRenderTextureFormat);
             _CommandBuffer.Blit(BuiltinRenderTextureType.CurrentActive, screenCopyID);
 
             int blurredID = Shader.PropertyToID("_Grab" + i + "_Temp1");
             int blurredID2 = Shader.PropertyToID("_Grab" + i + "_Temp2");
-            _CommandBuffer.GetTemporaryRT(blurredID, (int)sizes[i].x, (int)sizes[i].y, 0, FilterMode.Bilinear);
-            _CommandBuffer.GetTemporaryRT(blurredID2, (int)sizes[i].x, (int)sizes[i].y, 0, FilterMode.Bilinear);
+            _CommandBuffer.GetTemporaryRT(blurredID, (int)sizes[i].x, (int)sizes[i].y, 0, FilterMode.Bilinear, _BufferRenderTextureFormat);
+            _CommandBuffer.GetTemporaryRT(blurredID2, (int)sizes[i].x, (int)sizes[i].y, 0, FilterMode.Bilinear, _BufferRenderTextureFormat);
 
             _CommandBuffer.Blit(screenCopyID, blurredID);
             _CommandBuffer.ReleaseTemporaryRT(screenCopyID);

--- a/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
+++ b/Assets/FrostedGlass/Scripts/CommandBufferBlur.cs
@@ -14,7 +14,7 @@ public class CommandBufferBlur : MonoBehaviour
     CommandBuffer _CommandBuffer = null;
 
     Vector2 _ScreenResolution = Vector2.zero;
-    RenderTextureFormat _BufferRenderTextureFormat;
+    RenderTextureFormat _BufferRenderTextureFormat = RenderTextureFormat.ARGB32;
 
     public void Cleanup()
     {
@@ -64,11 +64,7 @@ public class CommandBufferBlur : MonoBehaviour
         _Camera = GetComponent<Camera>();
 
         if (_Camera.allowHDR && SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.DefaultHDR))
-        {
             _BufferRenderTextureFormat = RenderTextureFormat.DefaultHDR;
-        } else {
-            _BufferRenderTextureFormat = RenderTextureFormat.ARGB32;
-        }
 
         _CommandBuffer = new CommandBuffer();
         _CommandBuffer.name = "Blur screen";


### PR DESCRIPTION
As far as I can tell, this should be a reliable way of switching to HDR when it's appropriate.

There are a couple of things that I'm not sure about:
1) is `SystemInfo.SupportsRenderTextureFormat` an adequate test of whether the *active hardware tier* also supports it?
2) is this test even necessary, i.e. would Unity be smart enough to fall back to ARGB if necessary?

If people with a greater knowledge of Unity's HDR support (or with access to non-HDR-supporting hardware to test on) have suggestions, I'd welcome them, but for now this seems to work for supporting HDR when possible and also falling back when necessary, at least in theory.